### PR TITLE
Dots in linechart after enabling cohort

### DIFF
--- a/public/cohort.css
+++ b/public/cohort.css
@@ -2,7 +2,7 @@
   display: none;
 }
 
-.line {
+.cohort_line {
   fill: none;
   stroke: steelblue;
   stroke-width: 2.5px;

--- a/public/cohort_controller.js
+++ b/public/cohort_controller.js
@@ -235,7 +235,7 @@ module.controller('cohort_controller', function($scope, $element, Private) {
             .attr("class", "cohortDate");
 
         cohortDate.append("path")
-            .attr("class", "line")
+            .attr("class", "cohort_line")
             .attr("d", function(d) { return line(d.values); })
             .style("stroke", function(d) { return z(d.key); });
 


### PR DESCRIPTION
Dear elo7,
due to a css conflict, the stock line chart of kibana gets polluted with blue dots.
Just renaming the css class from ".line" to ".cohort_line" fixes the anomaly.

![68799932-3fbb-11e7-9d77-162557aa5299](https://cloud.githubusercontent.com/assets/11296689/26374491/ccd9ef04-4005-11e7-8915-9384806cd9bd.png)
