### PR TITLE
[EM-17565] - Upgrade to Elasticsearch & Kibana para 5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohort",
-  "version": "5.4.3",
+  "version": "5.5.1",
   "description": "Cohort Analysis plugin built with love at Elo7",
   "main": "index.js",
   "scripts": {

--- a/public/cohort.js
+++ b/public/cohort.js
@@ -1,17 +1,18 @@
 // Include the angular controller
 
-import 'plugins/cohort/cohort.css'
-import cohort_controller from 'plugins/cohort/cohort_controller';
 import cohort_params_template from 'plugins/cohort/cohort_params.html';
-import TemplateVisTypeTemplateVisTypeProvider from 'ui/template_vis_type/template_vis_type';
-import VisSchemasProvider from 'ui/vis/schemas';
+import cohort_template from 'plugins/cohort/cohort.html';
+import { VisSchemasProvider } from 'ui/vis/schemas';
+import { TemplateVisTypeProvider } from 'ui/template_vis_type/template_vis_type';
+import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
 
-// The provider function, which must return our new visualization type
+import 'plugins/cohort/cohort_controller';
+import 'plugins/cohort/cohort.css'
 
-function CohortProvider(Private) {
+VisTypesRegistryProvider.register(function CohortProvider(Private) {
 
     // Describe our visualization
-    const TemplateVisType = Private(TemplateVisTypeTemplateVisTypeProvider);
+    const TemplateVisType = Private(TemplateVisTypeProvider);
     const Schemas = Private(VisSchemasProvider);
 
     return new TemplateVisType({
@@ -19,7 +20,7 @@ function CohortProvider(Private) {
         title: 'Cohort Analysis',
         description: 'Cohort analysis plugin',
         icon: 'fa-user', // The font awesome icon of this visualization
-        template: require('plugins/cohort/cohort.html'),
+        template: cohort_template,
         params: {
             defaults: {
                 percentual: false
@@ -61,6 +62,5 @@ function CohortProvider(Private) {
             }
         ])
     });
-}
+});
 
-require('ui/registry/vis_types').register(CohortProvider);

--- a/public/cohort_controller.js
+++ b/public/cohort_controller.js
@@ -1,11 +1,12 @@
 
 import d3 from 'd3';
-import AggResponseTabifyTabifyProvider from 'ui/agg_response/tabify/tabify';
-var module = require('ui/modules').get('cohort');
+import { AggResponseTabifyProvider } from 'ui/agg_response/tabify/tabify';
+import { uiModules } from 'ui/modules';
 
+const module = uiModules.get('cohort');
 module.controller('cohort_controller', function($scope, $element, Private) {
 
-    const tabifyAggResponse = Private(AggResponseTabifyTabifyProvider);
+    const tabifyAggResponse = Private(AggResponseTabifyProvider);
     const round = function(v){ return Math.round(v * 100) / 100; };
     const red = "#ff4e61";
     const yellow = "#ffef7d";


### PR DESCRIPTION
🔨 @givasthefirst @mikedias @ericvinicius 
👍  @ericvinicius

# Changelog

- New version of the plugin to work with version 5.5.1 of Kibana and Elasticsearch

# Pre-Tests
- Node version ```v6.11.1```, to check it out run ```node -v```
- Download Kibana source code ```git clone git@github.com:elastic/kibana.git ```
- Checkout to tag ```git checkout tags/v5.5.1```
- Configure your kibana.yml to point to localhost and a local elasticsearch
- Download Elasticsearch and Start It 
```shell
wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.1.tar.gz
sha1sum elasticsearch-5.5.1.tar.gz 
tar -xzf elasticsearch-5.5.1.tar.gz
cd elasticsearch-5.5.1/bin
./elasticsearch
```
- Put some data into your local Elasticsearch to test with data

# Tests
- Build Kibana ```npm install```
- Build the plugin ```npm install```
- Start the plugin pointing to kibana.yml
```shell
 npm start -- --config ../kibana/config/kibana.yml
```
- Open Kibana and use the Cohort plugin
- Everything should work fine

 
